### PR TITLE
Add Mod Menu dependency to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,17 @@ version = "1.0.0"
 minecraft {
 }
 
+repositories {
+	maven { url = "https://maven.fabricmc.net/" }
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:1.14.4"
 	mappings "net.fabricmc:yarn:1.14.4+build.5"
 	modApi "net.fabricmc:fabric-loader:0.4.8+build.159"
 	modApi "net.fabricmc.fabric-api:fabric-api:0.3.0+build.207"
+
+	modApi ("io.github.prospector:modmenu:1.7.9+build.118")
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task


### PR DESCRIPTION
Adds the latest version of 1.14.4 Mod Menu (1.7.9+118) to the project. 