### PR TITLE
Add mod ItemGroup

### DIFF
--- a/src/main/java/com/fabriccommunity/spookytime/SpookyTime.java
+++ b/src/main/java/com/fabriccommunity/spookytime/SpookyTime.java
@@ -2,6 +2,9 @@ package com.fabriccommunity.spookytime;
 
 import com.fabriccommunity.spookytime.registry.*;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -9,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 public class SpookyTime implements ModInitializer {
 	public static final String MOD_ID = "spookytime";
 	public static final Logger LOGGER = LogManager.getLogger("Spooky Time");
+	public static final ItemGroup GROUP = FabricItemGroupBuilder.build(new Identifier(MOD_ID, "group"), () -> new ItemStack(SpookyItems.REAPERS_SCYTHE));
 	
 	public static Identifier id(String name) {
 		return new Identifier(MOD_ID, name);

--- a/src/main/java/com/fabriccommunity/spookytime/registry/SpookyItems.java
+++ b/src/main/java/com/fabriccommunity/spookytime/registry/SpookyItems.java
@@ -12,23 +12,23 @@ import net.minecraft.util.Rarity;
 import net.minecraft.util.registry.Registry;
 
 public class SpookyItems {
-    public static Item BLAZE_SKIRT = register("blaze_skirt", new SkirtCostume(new Item.Settings().group(ItemGroup.MISC).maxCount(1)));
+    public static Item BLAZE_SKIRT = register("blaze_skirt", new SkirtCostume(new Item.Settings().group(SpookyTime.GROUP).maxCount(1)));
 
-    public static Item CARAMEL_APPLE = register("caramel_apple", new CandyItem(new Item.Settings().group(ItemGroup.FOOD), 5, 0.3F));
-    public static Item PUMPKIN_CANDY = register("pumpkin_candy", new CandyItem(new Item.Settings().group(ItemGroup.FOOD), 2, 0.3F));
-    public static Item RARE_CANDY = register("rare_candy", new CandyItem(new Item.Settings().group(ItemGroup.FOOD), 1, 0.1F));
-    public static Item WINGED_STRAWBERRY_CANDY = register("winged_strawberry_candy", new CandyItem(new Item.Settings().group(ItemGroup.FOOD), 3, 0.3F));
-    public static Item BAKED_PUMPKIN_SEEDS = register("baked_pumpkin_seeds", new Item(new Item.Settings().group(ItemGroup.FOOD).food(new FoodComponent.Builder().hunger(2).saturationModifier(0.2f).snack().build())));
+    public static Item CARAMEL_APPLE = register("caramel_apple", new CandyItem(new Item.Settings().group(SpookyTime.GROUP), 5, 0.3F));
+    public static Item PUMPKIN_CANDY = register("pumpkin_candy", new CandyItem(new Item.Settings().group(SpookyTime.GROUP), 2, 0.3F));
+    public static Item RARE_CANDY = register("rare_candy", new CandyItem(new Item.Settings().group(SpookyTime.GROUP), 1, 0.1F));
+    public static Item WINGED_STRAWBERRY_CANDY = register("winged_strawberry_candy", new CandyItem(new Item.Settings().group(SpookyTime.GROUP), 3, 0.3F));
+    public static Item BAKED_PUMPKIN_SEEDS = register("baked_pumpkin_seeds", new Item(new Item.Settings().group(SpookyTime.GROUP).food(new FoodComponent.Builder().hunger(2).saturationModifier(0.2f).snack().build())));
 
-    public static Item SPOOKIUM_INGOT = register("spookium_ingot", new Item(new Item.Settings().group(ItemGroup.MATERIALS).rarity(Rarity.EPIC)));
-    public static Item SPOOKIUM_NUGGET = register("spookium_nugget", new Item(new Item.Settings().group(ItemGroup.MATERIALS).rarity(Rarity.EPIC)));
+    public static Item SPOOKIUM_INGOT = register("spookium_ingot", new Item(new Item.Settings().group(SpookyTime.GROUP).rarity(Rarity.EPIC)));
+    public static Item SPOOKIUM_NUGGET = register("spookium_nugget", new Item(new Item.Settings().group(SpookyTime.GROUP).rarity(Rarity.EPIC)));
 
     public static ToolMaterial SPOOKIUM = new SpookiumMaterial();
-    public static Item REAPERS_SCYTHE = register("reapers_scythe", new ScytheItem(SPOOKIUM, 3, -2.0F, new Item.Settings().group(ItemGroup.COMBAT).maxCount(1).rarity(Rarity.EPIC)));
+    public static Item REAPERS_SCYTHE = register("reapers_scythe", new ScytheItem(SPOOKIUM, 3, -2.0F, new Item.Settings().group(SpookyTime.GROUP).maxCount(1).rarity(Rarity.EPIC)));
 
-    public static Item SOUL_BOTTLE = register("soul_bottle", new Item(new Item.Settings().group(ItemGroup.MISC)));
+    public static Item SOUL_BOTTLE = register("soul_bottle", new Item(new Item.Settings().group(SpookyTime.GROUP)));
 
-    public static Item PUMPCOWN_SPAWN_EGG = register("pumpcown_spawn_egg", new SpawnEggItem(SpookyEntities.PUMPCOWN, 8273166, 14912029, new Item.Settings().group(ItemGroup.MISC)));
+    public static Item PUMPCOWN_SPAWN_EGG = register("pumpcown_spawn_egg", new SpawnEggItem(SpookyEntities.PUMPCOWN, 8273166, 14912029, new Item.Settings().group(SpookyTime.GROUP)));
 
     private SpookyItems() {
         // NO-OP

--- a/src/main/resources/assets/spookytime/lang/en_us.json
+++ b/src/main/resources/assets/spookytime/lang/en_us.json
@@ -5,6 +5,8 @@
     "spookytime.github": "https://github.com/fabric-community/spooky-time",
     "spookytime.contrib.title": "=====Contributors=====",
     "spookytime.contrib.entry": "%d, ",
+
+    "itemGroup.spookytime.group": "Spooky Time",
     
     "spookytime.cmd.spooktober": "It is Spooktober!",
     "spookytime.cmd.tillspooktober": "It is %d days till Spooktober",


### PR DESCRIPTION
Simple PR that adds in a single ItemGroup for the mod. It currently uses the Scythe item as an icon, but we can change that later if needed.

Fixes #38.