### PR TITLE
Add candy translations

### DIFF
--- a/src/main/resources/assets/spookytime/lang/en_us.json
+++ b/src/main/resources/assets/spookytime/lang/en_us.json
@@ -15,6 +15,10 @@
     "item.spookytime.spookium_nugget": "Spookium Nugget",
     "item.spookytime.soul_bottle": "Soul Bottle",
     "item.spookytime.reapers_scythe": "Reaper's Scythe",
+    "item.spookytime.pumpkin_candy": "Pumpkin Candy",
+    "item.spookytime.rare_candy": "Rare Candy",
+    "item.spookytime.winged_strawberry_candy": "Winged Strawberry Candy",
+    "item.spookytime.caramel_apple": "Caramel Apple",
     
     "block.spookytime.tiny_pumpkin": "§4T§6i§en§ay §4P§6u§em§ap§9k§di§6n",
     "block.spookytime.deceased_grass_block": "Deceased Grass Block",


### PR DESCRIPTION
This PR adds in 4 new translations:
  - `pumpkin_candy` -> `Pumpkin Candy`
  - `rare_candy` -> `Rare Candy`
  - `winged_strawberry_candy` -> `Winged Strawberry Candy`
  - `caramel_apple` -> `Caramel Apple`

Fixes #39.