### PR TITLE
Fix reaper's scythe json model

### DIFF
--- a/src/main/resources/assets/spookytime/models/item/reapers_scythe.json
+++ b/src/main/resources/assets/spookytime/models/item/reapers_scythe.json
@@ -1,5 +1,5 @@
 {
-    "parent": "item/generated",
+    "parent": "item/handheld",
     "textures": {
         "layer0": "spookytime:item/reapers_scythe"
     }


### PR DESCRIPTION
Changed the Reaper's Scythe model to use `item/handheld` (it previously used `item/generated`).

Fixes #40.