### PR TITLE
Trick or Treating Revamp + extras

### DIFF
--- a/src/main/java/com/fabriccommunity/spookytime/SpookyConfig.java
+++ b/src/main/java/com/fabriccommunity/spookytime/SpookyConfig.java
@@ -11,12 +11,16 @@ public class SpookyConfig {
 	public static void sync(boolean overwrite) {
 		modConfig.configure(overwrite, config -> {
 			config.accessChild("weather", weather -> {
-				SpookyWeather.thunderModifier = weather.getInt("thunder_modifier", SpookyWeather.thunderModifier, "Amount the thunder time is devided by. Set to 1 to disable");
+				SpookyWeather.thunderModifier = weather.getInt("thunder_modifier", SpookyWeather.thunderModifier, "Amount the thunder time is divided by. Set to 1 to disable");
 				SpookyWeather.lessClearSkies = weather.getBool("less_clear_skies", SpookyWeather.lessClearSkies, "Make it so there are less clear skies, more rain and thunder");
 			});
 			config.accessChild("pumpkins_on_mobs", pumpkinMobs -> {
 				PumpkinMobs.headArmor = pumpkinMobs.getBool("pumpkin_head", PumpkinMobs.headArmor, "Zombies, Skeletons, and Wither Skeletons have a 1/3 chance of spawning with a pumpkin on their head");
 				PumpkinMobs.endermen = pumpkinMobs.getBool("endermen_hold", PumpkinMobs.endermen, "Endermen have a 1/3 chance of spawning holding a pumpkin");
+			});
+			config.accessChild("trick_or_treating", trickOrTreating -> {
+				TrickOrTreating.enableTricks = trickOrTreating.getBool("enable_tricks", TrickOrTreating.enableTricks, "Enables a chance for trick or treating to result in the villagers becoming witches");
+				TrickOrTreating.trickChance = trickOrTreating.getInt("trick_chance", TrickOrTreating.trickChance, "Tricks, if enabled, will have a one in (this number) chance of happening");
 			});
 		});
 	}
@@ -29,5 +33,10 @@ public class SpookyConfig {
 	public static class PumpkinMobs {
 		public static boolean headArmor = true;
 		public static boolean endermen = true;
+	}
+	
+	public static class TrickOrTreating {
+		public static boolean enableTricks = true;
+		public static int trickChance = 100;
 	}
 }

--- a/src/main/java/com/fabriccommunity/spookytime/SpookyTime.java
+++ b/src/main/java/com/fabriccommunity/spookytime/SpookyTime.java
@@ -30,5 +30,6 @@ public class SpookyTime implements ModInitializer {
 		SpookyBiomes.init();
 		SpookyWorldGen.init();
 		SpookyDimensions.init();
+		SpookyTags.init();
 	}
 }

--- a/src/main/java/com/fabriccommunity/spookytime/item/tool/ScytheItem.java
+++ b/src/main/java/com/fabriccommunity/spookytime/item/tool/ScytheItem.java
@@ -4,6 +4,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.EntityCategory;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
@@ -21,6 +22,8 @@ public class ScytheItem extends SwordItem {
 		if (!target.isAlive()) {
 			if (target instanceof PlayerEntity) {
 				// give player soul
+			} else if (target instanceof WitherEntity) {
+				// give withered soul
 			} else {
 				EntityCategory category = target.getType().getCategory();
 				switch (category) {

--- a/src/main/java/com/fabriccommunity/spookytime/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/fabriccommunity/spookytime/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,8 +1,11 @@
 package com.fabriccommunity.spookytime.mixin;
 
+import com.fabriccommunity.spookytime.SpookyConfig;
+import com.fabriccommunity.spookytime.SpookyTime;
 import com.fabriccommunity.spookytime.component.CandyComponent;
 import com.fabriccommunity.spookytime.registry.SpookyEntities;
 import com.fabriccommunity.spookytime.registry.SpookyItems;
+import com.fabriccommunity.spookytime.registry.SpookyTags;
 import dev.emi.trinkets.api.TrinketsApi;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,17 +13,22 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ai.brain.task.LookTargetUtil;
+import net.minecraft.entity.mob.WitchEntity;
 import net.minecraft.entity.passive.VillagerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.MessageType;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.packet.ChatMessageC2SPacket;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
@@ -33,6 +41,7 @@ import net.minecraft.world.loot.context.LootContextTypes;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Handles trick or treat functionality when saying "trick or treat" to a villager.
@@ -41,55 +50,69 @@ import java.util.List;
  */
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin {
-	private static final List<Item> costumeItems = new ArrayList<Item>();
-	
-	static {
-		costumeItems.add(Items.ZOMBIE_HEAD);
-		costumeItems.add(Items.CREEPER_HEAD);
-		costumeItems.add(Items.DRAGON_HEAD);
-		costumeItems.add(Items.PLAYER_HEAD);
-		costumeItems.add(Items.SKELETON_SKULL);
-		costumeItems.add(Items.WITHER_SKELETON_SKULL);
-		costumeItems.add(Items.CARVED_PUMPKIN);
-		costumeItems.add(SpookyItems.BLAZE_SKIRT);
-	}
-	
 	@Shadow
 	public ServerPlayerEntity player;
 	
 	@Inject(at = @At("TAIL"), method = "onChatMessage")
 	public void onChatMessage(ChatMessageC2SPacket packet, CallbackInfo info) {
-		if (packet.getChatMessage().toLowerCase().equals("trick or treat") && isPlayerWearingCostume(player)) {
-			World world = player.getEntityWorld();
-			Box box = new Box(player.x - 3, player.y - 3, player.z - 3, player.x + 3, player.y + 3, player.z + 3);
-			List<VillagerEntity> villagers = world.getEntities(VillagerEntity.class, box);
-			Iterator<VillagerEntity> iterator = villagers.iterator();
-			while (iterator.hasNext()) {
-				VillagerEntity entity = iterator.next();
-				CandyComponent comp = SpookyEntities.CANDY.get(entity);
-				if (comp.canGiveCandy(player)) {
-					comp.setLastCandyTime(player, world.getTime());
-					LootSupplier supplier = world.getServer().getLootManager().getSupplier(new Identifier("spookytime", "gameplay/trick_or_treat_candy"));
-					LootContext context = (new LootContext.Builder((ServerWorld) world))
-							.put(LootContextParameters.POSITION, new BlockPos(entity))
-							.put(LootContextParameters.THIS_ENTITY, entity).setRandom(entity.getRand())
-							.build(LootContextTypes.GIFT);
-					List<ItemStack> stacks = supplier.getDrops(context);
-					for (ItemStack stack : stacks) {
-						LookTargetUtil.give(entity, stack, player);
+		if (packet.getChatMessage().toLowerCase().contains("trick or treat")) {
+			if(isPlayerWearingCostume(player)) {
+				World world = player.getEntityWorld();
+				Box box = new Box(player.x - 3, player.y - 3, player.z - 3, player.x + 3, player.y + 3, player.z + 3);
+				List<VillagerEntity> villagers = world.getEntities(VillagerEntity.class, box);
+				Iterator<VillagerEntity> iterator = villagers.iterator();
+				if(iterator.hasNext()) {
+					boolean trick = SpookyConfig.TrickOrTreating.enableTricks && world.random.nextInt(SpookyConfig.TrickOrTreating.trickChance) == 0;
+					if (trick) {
+						player.playSound(SoundEvents.ENTITY_VILLAGER_NO, 1.0f, 1.0f);
+						player.sendChatMessage(new TranslatableText("text.spookytime.trick"), MessageType.GAME_INFO);
+					} else {
+						player.playSound(SoundEvents.ENTITY_VILLAGER_YES, 1.0f, 1.0f);
+						player.sendChatMessage(new TranslatableText("text.spookytime.treat"), MessageType.GAME_INFO);
 					}
+					while (iterator.hasNext()) {
+						VillagerEntity entity = iterator.next();
+						if (!entity.isBaby()) {
+							if (trick) {
+								WitchEntity witch = new WitchEntity(EntityType.WITCH, world);
+								witch.setPosition(entity.x, entity.y, entity.z);
+								witch.setYaw(entity.getYaw(1.0F));
+								witch.setAttacker(player);
+								entity.remove();
+								world.spawnEntity(witch);
+							} else {
+								CandyComponent comp = SpookyEntities.CANDY.get(entity);
+								if (comp.canGiveCandy(player)) {
+									comp.setLastCandyTime(player, world.getTime());
+									LootSupplier supplier = world.getServer().getLootManager().getSupplier(new Identifier("spookytime", "gameplay/trick_or_treat_candy"));
+									LootContext context = (new LootContext.Builder((ServerWorld) world))
+											.put(LootContextParameters.POSITION, new BlockPos(entity))
+											.put(LootContextParameters.THIS_ENTITY, entity).setRandom(entity.getRand())
+											.build(LootContextTypes.GIFT);
+									List<ItemStack> stacks = supplier.getDrops(context);
+									for (ItemStack stack : stacks) {
+										LookTargetUtil.give(entity, stack, player);
+									}
+								}
+							}
+						}
+					}
+				} else {
+					player.sendChatMessage(new TranslatableText("text.spookytime.no_one_nearby"), MessageType.GAME_INFO);
 				}
+			} else {
+				player.sendChatMessage(new TranslatableText("text.spookytime.not_wearing_costume"), MessageType.GAME_INFO);
 			}
 		}
 	}
 	
 	private boolean isPlayerWearingCostume(PlayerEntity player) {
 		for (int i = 0; i < 4; i++) {
-			if (costumeItems.contains(player.inventory.getArmorStack(i).getItem())) return true;
+			if (SpookyTags.COSTUMES.contains(player.inventory.getArmorStack(i).getItem())) return true;
 		}
 		Inventory inv = TrinketsApi.getTrinketsInventory(player);
 		for (int i = 0; i < inv.getInvSize(); i++) {
-			if (costumeItems.contains(inv.getInvStack(i).getItem())) return true;
+			if (SpookyTags.COSTUMES.contains(inv.getInvStack(i).getItem())) return true;
 		}
 		return false;
 	}

--- a/src/main/java/com/fabriccommunity/spookytime/registry/SpookyTags.java
+++ b/src/main/java/com/fabriccommunity/spookytime/registry/SpookyTags.java
@@ -1,0 +1,19 @@
+package com.fabriccommunity.spookytime.registry;
+
+import com.fabriccommunity.spookytime.SpookyTime;
+
+import net.minecraft.item.Item;
+import net.minecraft.tag.ItemTags;
+import net.minecraft.tag.Tag;
+
+public class SpookyTags {
+	public static Tag<Item> COSTUMES = new ItemTags.CachingTag(SpookyTime.id("costumes"));
+	
+	private SpookyTags() {
+		// NO-OP
+	}
+	
+	public static void init() {
+	
+	}
+}

--- a/src/main/java/com/fabriccommunity/spookytime/world/dimension/SpookySkyAngleCalculator.java
+++ b/src/main/java/com/fabriccommunity/spookytime/world/dimension/SpookySkyAngleCalculator.java
@@ -18,7 +18,7 @@ public class SpookySkyAngleCalculator implements SkyAngleCalculator {
 	}
 	
 	protected float zigzagDayFunction(long ticks) {
-		return repeatThisVee((ticks - cycleLength - cycleStart) % (2 * cycleLength));
+		return repeatThisVee((long) ((ticks - cycleLength - cycleStart) % (2 * cycleLength)));
 	}
 	
 	protected float waveDayFunction(long ticks) {

--- a/src/main/resources/assets/spookytime/lang/en_us.json
+++ b/src/main/resources/assets/spookytime/lang/en_us.json
@@ -39,6 +39,12 @@
     
     "biome.spookytime.spooky_forest": "Spooky Forest",
     "biome.spookytime.spooky_lowlands": "Spooky Lowlands",
+    
     "social.spookytime.github": "GitHub",
-    "social.spookytime.minecraft": "Minecraft"
+    "social.spookytime.minecraft": "Minecraft",
+    
+    "text.spookytime.trick": "Trick!",
+    "text.spookytime.treat": "Treat!",
+    "text.spookytime.no_one_nearby": "No one heard you!",
+    "text.spookytime.not_wearing_costume": "You're not wearing a costume!"
 }

--- a/src/main/resources/data/minecraft/tags/blocks/bamboo_plantable_on.json
+++ b/src/main/resources/data/minecraft/tags/blocks/bamboo_plantable_on.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "spookytime:tainted_sand",
+        "spookytime:tainted_gravel"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/dirt_like.json
+++ b/src/main/resources/data/minecraft/tags/blocks/dirt_like.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "spookytime:deceased_dirt",
+        "spookytime:deceased_grass_block"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/enderman_holdable.json
+++ b/src/main/resources/data/minecraft/tags/blocks/enderman_holdable.json
@@ -1,0 +1,9 @@
+{
+    "replace": false,
+    "values": [
+        "spookytime:deceased_dirt",
+        "spookytime:deceased_grass_block",
+        "spookytime:tainted_sand",
+        "spookytime:tainted_gravel"
+    ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/impermeable.json
+++ b/src/main/resources/data/minecraft/tags/blocks/impermeable.json
@@ -1,0 +1,7 @@
+{
+    "replace": false,
+    "values": [
+        "spookytime:tainted_glass",
+        "spookytime:soul_glass"
+    ]
+}

--- a/src/main/resources/data/spookytime/loot_tables/gameplay/trick_or_treat_candy.json
+++ b/src/main/resources/data/spookytime/loot_tables/gameplay/trick_or_treat_candy.json
@@ -7,22 +7,37 @@
 				{
 					"type": "minecraft:item",
 					"name": "spookytime:caramel_apple",
-					"weight": 10
+					"weight": 50
 				},
 				{
 					"type": "minecraft:item",
 					"name": "spookytime:pumpkin_candy",
-					"weight": 10
+					"weight": 50
 				},
 				{
 					"type": "minecraft:item",
 					"name": "spookytime:rare_candy",
-					"weight": 1
+					"weight": 5
 				},
 				{
 					"type": "minecraft:item",
 					"name": "spookytime:winged_strawberry_candy",
+					"weight": 30
+				},
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:cookie",
+					"weight": 20
+				},
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:cake",
 					"weight": 5
+				},
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:golden_apple",
+					"weight": 1
 				}
 			]
 		}

--- a/src/main/resources/data/spookytime/recipes/baked_pumpkin_seeds_smoking.json
+++ b/src/main/resources/data/spookytime/recipes/baked_pumpkin_seeds_smoking.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "item": "minecraft:pumpkin_seeds"
+  },
+  "result": "spookytime:baked_pumpkin_seeds",
+  "experience": 0.05,
+  "cookingtime": 25
+}

--- a/src/main/resources/data/spookytime/tags/items/costumes.json
+++ b/src/main/resources/data/spookytime/tags/items/costumes.json
@@ -1,0 +1,13 @@
+{
+    "replace": false,
+    "values": [
+        "minecraft:carved_pumpkin",
+        "minecraft:zombie_head",
+        "minecraft:skeleton_skull",
+        "minecraft:wither_skeleton_skull",
+        "minecraft:creeper_head",
+        "minecraft:dragon_head",
+        "minecraft:player_head",
+        "spookytime:blaze_skirt"
+    ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
 {
   "schemaVersion": 1,
   "id": "spookytime",
-  "version": "${version}",
+  "version": "1.0.0",
 
   "name": "Spooky Time",
   "description": "Time to get spooky! This mod was a collaboration by the Fabric community made for Hacktoberfest 2019.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
 {
   "schemaVersion": 1,
   "id": "spookytime",
-  "version": "1.0.0",
+  "version": "${version}",
 
   "name": "Spooky Time",
   "description": "Time to get spooky! This mod was a collaboration by the Fabric community made for Hacktoberfest 2019.",


### PR DESCRIPTION
- Trick or Treating now has a 1 in 100 (configurable) chance of resulting in a 'trick'
- Tricks will turn nearby villagers into witches instead of having them give you candy
- Tricks can be disabled altogether in the config
- A message now shows up on the action bar when you are trick or treating, which tells you the outcome (or why it's not working)
- Costumes are now defined in an item tag
- Baby Villagers no longer respond to trick or treating
- Baked Pumpkin Seeds can now be made in a Smoker
- Small other changes