### PR TITLE
Water bug fix for #127. Yes it's 2 lines long

### DIFF
--- a/src/main/resources/data/minecraft/tags/fluids/water.json
+++ b/src/main/resources/data/minecraft/tags/fluids/water.json
@@ -4,6 +4,8 @@
 		"spookytime:witch_water",
 		"spookytime:witch_water_flowing",
 		"spookytime:blood",
-		"spookytime:blood_flowing"
+		"spookytime:blood_flowing",
+		"minecraft:water",
+		"minecraft:flowing_water"
 	]
 }


### PR DESCRIPTION
Because we directly override water.json within the mod, we did not add ''minecraft:water'' & ''minecraft:flowing_water'' to the entries.