### PR TITLE
Fix double MC version in CF sources jar display name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ curseforge {
 			}
 			
 			addArtifact(sourcesJar) {
-				displayName = "${archives_base_name}-${minecraft_version}-${project.version}-sources.jar"
+				displayName = "${archives_base_name}-${project.version}-sources.jar"
 			}
 			
 			afterEvaluate {


### PR DESCRIPTION
Since `project.version` already contains the MC version.