### PR TITLE
Updated Trinkets to 2.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ rei_version=3.1.5+build.7
 
 cardinal_components_version=2.0.3
 tiny_config_version=1.1.2
-trinkets_version=v1.2.0
+trinkets_version=v2.1.0
 world_traveler_version=1.0.4
 
 

--- a/src/main/java/com/fabriccommunity/thehallow/item/HallowCharmItem.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/HallowCharmItem.java
@@ -7,6 +7,8 @@ import com.fabriccommunity.thehallow.registry.HallowedDimensions;
 import com.fabriccommunity.thehallow.registry.HallowedItems;
 import com.mojang.blaze3d.platform.GlStateManager;
 import dev.emi.trinkets.api.ITrinket;
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
 import net.fabricmc.fabric.api.dimension.v1.EntityPlacer;
 import net.fabricmc.fabric.api.dimension.v1.FabricDimensions;
 import net.fabricmc.fabric.api.util.NbtType;
@@ -123,7 +125,7 @@ public class HallowCharmItem extends Item implements ITrinket {
 
 	@Override
 	public boolean canWearInSlot(String group, String slot) {
-		return group.contains("head") && slot.contains("necklace");
+		return group.contains(SlotGroups.HEAD) && slot.contains(Slots.NECKLACE);
 	}
 
 	@Override

--- a/src/main/java/com/fabriccommunity/thehallow/item/PaperBagItem.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/PaperBagItem.java
@@ -1,26 +1,38 @@
 package com.fabriccommunity.thehallow.item;
 
+import net.minecraft.block.DispenserBlock;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 
 import dev.emi.trinkets.api.ITrinket;
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
 
 import java.util.List;
 
 public class PaperBagItem extends Item implements ITrinket {
 	public PaperBagItem(Settings settings) {
 		super(settings);
+		DispenserBlock.registerBehavior(this, TRINKET_DISPENSER_BEHAVIOR);
 	}
 	
 	@Override
 	public boolean canWearInSlot(String group, String slot) {
-		return group.equals("head") && slot.equals("mask");
+		return group.equals(SlotGroups.HEAD) && slot.equals(Slots.MASK);
+	}
+	
+	@Override
+	public TypedActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
+		return ITrinket.equipTrinket(player, hand);
 	}
 	
 	@Override

--- a/src/main/java/com/fabriccommunity/thehallow/item/PumpkinRing.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/PumpkinRing.java
@@ -3,6 +3,8 @@ package com.fabriccommunity.thehallow.item;
 import java.util.List;
 
 import dev.emi.trinkets.api.ITrinket;
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.player.PlayerEntity;
@@ -22,6 +24,11 @@ public class PumpkinRing extends Item implements ITrinket {
 	}
 	
 	@Override
+	public boolean canWearInSlot(String group, String slot) {
+		return group.contains(SlotGroups.HAND) && slot.equals(Slots.RING);
+	}
+	
+	@Override
 	public TypedActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
 		return ITrinket.equipTrinket(player, hand);
 	}
@@ -30,10 +37,5 @@ public class PumpkinRing extends Item implements ITrinket {
 	public void appendTooltip(ItemStack itemStack, World world, List<Text> list, TooltipContext context) {
 		list.add(new TranslatableText("tooltip.thehallow.pumpkin_ring").formatted(Formatting.GRAY));
 		super.appendTooltip(itemStack, world, list, context);
-	}
-	
-	@Override
-	public boolean canWearInSlot(String group, String slot) {
-		return group.contains("hand") && slot.equals("ring");
 	}
 }

--- a/src/main/java/com/fabriccommunity/thehallow/item/SkirtCostume.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/SkirtCostume.java
@@ -19,6 +19,8 @@ import net.minecraft.world.World;
 import com.mojang.blaze3d.platform.GlStateManager;
 
 import dev.emi.trinkets.api.ITrinket;
+import dev.emi.trinkets.api.SlotGroups;
+import dev.emi.trinkets.api.Slots;
 
 public class SkirtCostume extends Item implements ITrinket {
 	public SkirtCostume(Settings settings) {
@@ -33,7 +35,7 @@ public class SkirtCostume extends Item implements ITrinket {
 	
 	@Override
 	public boolean canWearInSlot(String group, String slot) {
-		return group.equals("legs") && slot.equals("belt");
+		return group.equals(SlotGroups.LEGS) && slot.equals(Slots.BELT);
 	}
 	
 	@Override

--- a/src/main/java/com/fabriccommunity/thehallow/registry/HallowedItems.java
+++ b/src/main/java/com/fabriccommunity/thehallow/registry/HallowedItems.java
@@ -70,10 +70,10 @@ public class HallowedItems {
 	}
 	
 	public static void init() {
-		TrinketSlots.addSubSlot(SlotGroups.LEGS, Slots.BELT, new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
-		TrinketSlots.addSubSlot(SlotGroups.HAND, Slots.RING, new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
-		TrinketSlots.addSubSlot(SlotGroups.HEAD, Slots.MASK, new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
-		TrinketSlots.addSubSlot(SlotGroups.HEAD, Slots.NECKLACE, new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
+		TrinketSlots.addSlot(SlotGroups.LEGS, Slots.BELT, new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
+		TrinketSlots.addSlot(SlotGroups.HAND, Slots.RING, new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+		TrinketSlots.addSlot(SlotGroups.HEAD, Slots.MASK, new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
+		TrinketSlots.addSlot(SlotGroups.HEAD, Slots.NECKLACE, new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
 		
 		PumpkinFoods.registerPumpkinFood(Items.PUMPKIN_PIE);
 		PumpkinFoods.registerPumpkinFood(HallowedItems.BAKED_PUMPKIN_SEEDS);


### PR DESCRIPTION
* Updated Trinkets to 2.1.0 and modified broken calls
* Made trinket items compare against constants instead of strings
* Added dispenser and right click trinket equipping to all trinkets that lacked it (except the hallowed charm, which has a right click use already)