### PR TITLE
Add a custom underwater fog system, add water vaporization config options.

### DIFF
--- a/src/main/java/com/fabriccommunity/thehallow/HallowedConfig.java
+++ b/src/main/java/com/fabriccommunity/thehallow/HallowedConfig.java
@@ -112,6 +112,9 @@ public class HallowedConfig {
 		
 	//serializer
 	public static void saveTo(JsonObject obj) {
+		JsonObject dimension = defaultPutButNotNull("dimension", new JsonObject(), obj);
+		dimension.putDefault("water_vaporizes", HallowedDimension.waterVaporizes, "Changed whether or not water vaporizes in The Hallow");
+
 		JsonObject weather = defaultPutButNotNull("weather", new JsonObject(), obj);
 		weather.putDefault("thunder_modifier", HallowedWeather.thunderModifier, "Amount the thunder time is divided by. Set to 1 to disable");
 		weather.putDefault("less_clear_skies", HallowedWeather.lessClearSkies, "Make it so there are less clear skies, more rain and thunder");

--- a/src/main/java/com/fabriccommunity/thehallow/HallowedConfig.java
+++ b/src/main/java/com/fabriccommunity/thehallow/HallowedConfig.java
@@ -42,6 +42,10 @@ public class HallowedConfig {
 			TheHallow.LOGGER.error("The Hallow config could not be written. This probably won't cause any problems, but it shouldn't happen.", e);
 		}
 	}
+
+	public static class HallowedDimension {
+		public static boolean waterVaporizes = true;
+	}
 	
 	public static class HallowedWeather {
 		public static int thunderModifier = 80;
@@ -77,6 +81,9 @@ public class HallowedConfig {
 	
 	//deserializer
 	public static void loadFrom(JsonObject obj) {
+		JsonObject dimension = getObjectOrEmpty("dimension", obj);
+		HallowedDimension.waterVaporizes = dimension.getBoolean("water_vaporizes", HallowedDimension.waterVaporizes);
+
 		JsonObject weather = getObjectOrEmpty("weather", obj);
 		HallowedWeather.thunderModifier = weather.getInt("thunder_modifier", HallowedWeather.thunderModifier);
 		HallowedWeather.lessClearSkies = weather.getBoolean("less_clear_skies", HallowedWeather.lessClearSkies);

--- a/src/main/java/com/fabriccommunity/thehallow/api/HallowedFluidInfo.java
+++ b/src/main/java/com/fabriccommunity/thehallow/api/HallowedFluidInfo.java
@@ -1,0 +1,5 @@
+package com.fabriccommunity.thehallow.api;
+
+public interface HallowedFluidInfo {
+	int getFogColor();
+}

--- a/src/main/java/com/fabriccommunity/thehallow/fluid/BloodFluid.java
+++ b/src/main/java/com/fabriccommunity/thehallow/fluid/BloodFluid.java
@@ -1,8 +1,12 @@
 package com.fabriccommunity.thehallow.fluid;
 
+import com.fabriccommunity.thehallow.api.HallowedFluidInfo;
+import com.fabriccommunity.thehallow.registry.HallowedBlocks;
+import com.fabriccommunity.thehallow.registry.HallowedFluids;
+import com.fabriccommunity.thehallow.registry.HallowedItems;
+import com.fabriccommunity.thehallow.registry.HallowedTags;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FluidBlock;
@@ -20,12 +24,12 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.WorldView;
 
-import com.fabriccommunity.thehallow.registry.HallowedBlocks;
-import com.fabriccommunity.thehallow.registry.HallowedFluids;
-import com.fabriccommunity.thehallow.registry.HallowedItems;
-import com.fabriccommunity.thehallow.registry.HallowedTags;
+public class BloodFluid extends BaseFluid implements HallowedFluidInfo {
+	@Override
+	public int getFogColor() {
+		return 0xBB0A1E;
+	}
 
-public class BloodFluid extends BaseFluid {
 	@Override
 	public Fluid getFlowing() {
 		return HallowedFluids.FLOWING_BLOOD;

--- a/src/main/java/com/fabriccommunity/thehallow/fluid/WitchWaterFluid.java
+++ b/src/main/java/com/fabriccommunity/thehallow/fluid/WitchWaterFluid.java
@@ -1,8 +1,12 @@
 package com.fabriccommunity.thehallow.fluid;
 
+import com.fabriccommunity.thehallow.api.HallowedFluidInfo;
+import com.fabriccommunity.thehallow.registry.HallowedBlocks;
+import com.fabriccommunity.thehallow.registry.HallowedFluids;
+import com.fabriccommunity.thehallow.registry.HallowedItems;
+import com.fabriccommunity.thehallow.registry.HallowedTags;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FluidBlock;
@@ -21,14 +25,14 @@ import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldView;
 
-import com.fabriccommunity.thehallow.registry.HallowedBlocks;
-import com.fabriccommunity.thehallow.registry.HallowedFluids;
-import com.fabriccommunity.thehallow.registry.HallowedItems;
-import com.fabriccommunity.thehallow.registry.HallowedTags;
-
 import java.util.Random;
 
-public class WitchWaterFluid extends BaseFluid {
+public class WitchWaterFluid extends BaseFluid implements HallowedFluidInfo {
+	@Override
+	public int getFogColor() {
+		return 0x5900A3;
+	}
+
 	@Override
 	public Fluid getFlowing() {
 		return HallowedFluids.FLOWING_WITCH_WATER;

--- a/src/main/java/com/fabriccommunity/thehallow/mixin/client/BiomeMixin.java
+++ b/src/main/java/com/fabriccommunity/thehallow/mixin/client/BiomeMixin.java
@@ -1,0 +1,25 @@
+package com.fabriccommunity.thehallow.mixin.client;
+
+import com.fabriccommunity.thehallow.api.HallowedFluidInfo;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.world.biome.Biome;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Makes water fog colors based on the fluid.
+ *
+ * @author Zundrel
+ */
+@Mixin(Biome.class)
+public class BiomeMixin {
+	@Inject(method = "Lnet/minecraft/world/biome/Biome;getWaterFogColor()I", at = @At(value = "HEAD"), cancellable = true)
+	private final void getWaterFogColor(CallbackInfoReturnable<Integer> cir) {
+		if (MinecraftClient.getInstance().gameRenderer.getCamera().getSubmergedFluidState().getFluid() instanceof HallowedFluidInfo) {
+			HallowedFluidInfo fluidInfo = (HallowedFluidInfo) MinecraftClient.getInstance().gameRenderer.getCamera().getSubmergedFluidState().getFluid();
+			cir.setReturnValue(fluidInfo.getFogColor());
+		}
+	}
+}

--- a/src/main/java/com/fabriccommunity/thehallow/registry/HallowedDimensions.java
+++ b/src/main/java/com/fabriccommunity/thehallow/registry/HallowedDimensions.java
@@ -1,5 +1,6 @@
 package com.fabriccommunity.thehallow.registry;
 
+import com.fabriccommunity.thehallow.HallowedConfig;
 import net.fabricmc.fabric.api.dimension.v1.EntityPlacer;
 import net.fabricmc.fabric.api.dimension.v1.FabricDimensionType;
 
@@ -29,6 +30,7 @@ public class HallowedDimensions {
 			.skyAngle(new HallowedSkyAngleCalculator())
 			.setChunkGenerator(HallowedChunkGeneratorType.INSTANCE.create(world, new HallowedBiomeSource(world.getSeed()), new HallowedChunkGeneratorConfig()))
 			.setLightLevelsToBrightness(getLightLevels())
+			.doesWaterVaporize(HallowedConfig.HallowedDimension.waterVaporizes)
 			.build(world, type))
 		.defaultPlacer(FIND_SURFACE)
 		.buildAndRegister(TheHallow.id("the_hallow"));

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/GhastlyDesert.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/GhastlyDesert.java
@@ -14,7 +14,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 
 public class GhastlyDesert extends HallowedBaseBiome {
 	public GhastlyDesert() {
-		super(new Settings().surfaceBuilder(DESERT_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.DESERT).precipitation(Biome.Precipitation.NONE).category(Biome.Category.DESERT).depth(0.125F).scale(0.05F).temperature(2.0F).downfall(0.0F).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(DESERT_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.DESERT).precipitation(Biome.Precipitation.NONE).category(Biome.Category.DESERT).depth(0.125F).scale(0.05F).temperature(2.0F).downfall(0.0F).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/GhastlyDesert.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/GhastlyDesert.java
@@ -14,7 +14,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 
 public class GhastlyDesert extends HallowedBaseBiome {
 	public GhastlyDesert() {
-		super(new Settings().surfaceBuilder(DESERT_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.DESERT).precipitation(Biome.Precipitation.NONE).category(Biome.Category.DESERT).depth(0.125F).scale(0.05F).temperature(2.0F).downfall(0.0F).waterColor(0xBB0A1E).waterFogColor(0xBB0A1E));
+		super(new Settings().surfaceBuilder(DESERT_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.DESERT).precipitation(Biome.Precipitation.NONE).category(Biome.Category.DESERT).depth(0.125F).scale(0.05F).temperature(2.0F).downfall(0.0F).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedForestBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedForestBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedForestBiome extends HallowedBaseBiome {
 	public HallowedForestBiome(float depth, float scale) {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.FOREST).depth(depth).scale(scale).temperature(0.7f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.FOREST).depth(depth).scale(scale).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		GRASS_COLOR = 0x6B6B6B;
 		FOLIAGE_COLOR = 0x6B6B6B;

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedForestBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedForestBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedForestBiome extends HallowedBaseBiome {
 	public HallowedForestBiome(float depth, float scale) {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.FOREST).depth(depth).scale(scale).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.FOREST).depth(depth).scale(scale).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		GRASS_COLOR = 0x6B6B6B;
 		FOLIAGE_COLOR = 0x6B6B6B;

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedLowlandsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedLowlandsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedLowlandsBiome extends HallowedBaseBiome {
 	public HallowedLowlandsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.08f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.08f).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedLowlandsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedLowlandsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedLowlandsBiome extends HallowedBaseBiome {
 	public HallowedLowlandsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.08f).temperature(0.7f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.08f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedRiverBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedRiverBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedRiverBiome extends HallowedBaseBiome {
 	public HallowedRiverBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.RIVER).depth(-0.5f).scale(0.1f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.RIVER).depth(-0.5f).scale(0.1f).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedRiverBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedRiverBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedRiverBiome extends HallowedBaseBiome {
 	public HallowedRiverBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.RIVER).depth(-0.5f).scale(0.1f).temperature(0.7f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.RIVER).depth(-0.5f).scale(0.1f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSeaBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSeaBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedSeaBiome extends HallowedBaseBiome {
 	public HallowedSeaBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(-1.2f).scale(0.1f).temperature(0.5f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(-1.2f).scale(0.1f).temperature(0.5f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSeaBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSeaBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedSeaBiome extends HallowedBaseBiome {
 	public HallowedSeaBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(-1.2f).scale(0.1f).temperature(0.5f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(-1.2f).scale(0.1f).temperature(0.5f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedShoreBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedShoreBiome.java
@@ -19,7 +19,7 @@ public class HallowedShoreBiome extends HallowedBaseBiome {
 	);
 	
 	public HallowedShoreBiome() {
-		super(new Settings().surfaceBuilder(new ConfiguredSurfaceBuilder<TernarySurfaceConfig>(SurfaceBuilder.DEFAULT, TAINTED_GRAVEL_CONFIG)).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(0.02f).scale(0.025f).temperature(0.5f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(new ConfiguredSurfaceBuilder<TernarySurfaceConfig>(SurfaceBuilder.DEFAULT, TAINTED_GRAVEL_CONFIG)).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(0.02f).scale(0.025f).temperature(0.5f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedShoreBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedShoreBiome.java
@@ -19,7 +19,7 @@ public class HallowedShoreBiome extends HallowedBaseBiome {
 	);
 	
 	public HallowedShoreBiome() {
-		super(new Settings().surfaceBuilder(new ConfiguredSurfaceBuilder<TernarySurfaceConfig>(SurfaceBuilder.DEFAULT, TAINTED_GRAVEL_CONFIG)).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(0.02f).scale(0.025f).temperature(0.5f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(new ConfiguredSurfaceBuilder<TernarySurfaceConfig>(SurfaceBuilder.DEFAULT, TAINTED_GRAVEL_CONFIG)).precipitation(Precipitation.NONE).category(Category.OCEAN).depth(0.02f).scale(0.025f).temperature(0.5f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSwampBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSwampBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedSwampBiome extends HallowedBaseBiome {
 	public HallowedSwampBiome() {
-		super(new Settings().surfaceBuilder(MARSH_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.SWAMP).depth(-0.2f).scale(0.18f).temperature(0.7f).downfall(0.8f).waterColor(0xBB0A1E).waterFogColor(0xBB0A1E));
+		super(new Settings().surfaceBuilder(MARSH_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.SWAMP).depth(-0.2f).scale(0.18f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		GRASS_COLOR = 0x2A2A2A;
 		FOLIAGE_COLOR = 0x2A2A2A;

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSwampBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HallowedSwampBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HallowedSwampBiome extends HallowedBaseBiome {
 	public HallowedSwampBiome() {
-		super(new Settings().surfaceBuilder(MARSH_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.SWAMP).depth(-0.2f).scale(0.18f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(MARSH_SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.SWAMP).depth(-0.2f).scale(0.18f).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		GRASS_COLOR = 0x2A2A2A;
 		FOLIAGE_COLOR = 0x2A2A2A;

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedMoorBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedMoorBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HauntedMoorBiome extends HallowedBaseBiome {
 	public HauntedMoorBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(3.15f).scale(0.22f).temperature(0.5f).downfall(0.4f).waterColor(0xBB0A1E).waterFogColor(0xBB0A1E));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(3.15f).scale(0.22f).temperature(0.5f).downfall(0.4f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedMoorBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedMoorBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HauntedMoorBiome extends HallowedBaseBiome {
 	public HauntedMoorBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(3.15f).scale(0.22f).temperature(0.5f).downfall(0.4f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(3.15f).scale(0.22f).temperature(0.5f).downfall(0.4f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedUplandsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedUplandsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HauntedUplandsBiome extends HallowedBaseBiome {
 	public HauntedUplandsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(1.75f).scale(0.03f).temperature(0.5f).downfall(0.4f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(1.75f).scale(0.03f).temperature(0.5f).downfall(0.4f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedUplandsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/HauntedUplandsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class HauntedUplandsBiome extends HallowedBaseBiome {
 	public HauntedUplandsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(1.75f).scale(0.03f).temperature(0.5f).downfall(0.4f).waterColor(0xBB0A1E).waterFogColor(0xBB0A1E));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(1.75f).scale(0.03f).temperature(0.5f).downfall(0.4f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/LowlandBarrowsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/LowlandBarrowsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class LowlandBarrowsBiome extends HallowedBaseBiome {
 	public LowlandBarrowsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.15f).scale(0.025f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.15f).scale(0.025f).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/LowlandBarrowsBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/LowlandBarrowsBiome.java
@@ -9,7 +9,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class LowlandBarrowsBiome extends HallowedBaseBiome {
 	public LowlandBarrowsBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.15f).scale(0.025f).temperature(0.7f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.15f).scale(0.025f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		this.addStructureFeature(Feature.MINESHAFT.configure(new MineshaftFeatureConfig(0.004D, MineshaftFeature.Type.NORMAL)));
 		

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/PumpkinPatchBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/PumpkinPatchBiome.java
@@ -16,7 +16,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class PumpkinPatchBiome extends HallowedBaseBiome {
 	public PumpkinPatchBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.07f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.07f).temperature(0.7f).downfall(0.8f).waterColor(0x3F76E4).waterFogColor(0x050533));
 		
 		GRASS_COLOR = 0xC9C92A;
 		FOLIAGE_COLOR = 0xC9C92A;

--- a/src/main/java/com/fabriccommunity/thehallow/world/biome/PumpkinPatchBiome.java
+++ b/src/main/java/com/fabriccommunity/thehallow/world/biome/PumpkinPatchBiome.java
@@ -16,7 +16,7 @@ import com.fabriccommunity.thehallow.world.feature.HallowedBiomeFeatures;
 // TODO
 public class PumpkinPatchBiome extends HallowedBaseBiome {
 	public PumpkinPatchBiome() {
-		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.07f).temperature(0.7f).downfall(0.8f).waterColor(0x5900A3).waterFogColor(0x5900A3));
+		super(new Settings().surfaceBuilder(SURFACE_BUILDER).precipitation(Precipitation.NONE).category(Category.PLAINS).depth(0.125f).scale(0.07f).temperature(0.7f).downfall(0.8f).waterColor(4159204).waterFogColor(329011));
 		
 		GRASS_COLOR = 0xC9C92A;
 		FOLIAGE_COLOR = 0xC9C92A;

--- a/src/main/resources/thehallow.mixins.json
+++ b/src/main/resources/thehallow.mixins.json
@@ -27,7 +27,8 @@
 		"client.FirstPersonRendererMixin",
 		"client.GameRendererMixin",
 		"client.SignBlockEntityRendererMixin",
-		"client.TexturedRenderLayersMixin"
+		"client.TexturedRenderLayersMixin",
+		"client.BiomeMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
This PR simply adds a client-side custom underwater fog system for our custom fluids. It does so with a simple 4 line mixin and an interface that's put directly on the fluids.

Additionally, default water color has been changed to the same as vanilla plains and water vaporization has been turned on by default in our dimension (although it has been given a config option).