### PR TITLE
fix crash-on-launch on dedicated servers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ fabric_version=0.4.25+build.282-1.15
 
 maven_group=fabric-community
 archives_base_name=TheHallow
-mod_version=1.1.2-beta
+mod_version=1.1.3-beta
 
 license_header=MIT
 

--- a/src/main/java/com/fabriccommunity/thehallow/item/HallowCharmItem.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/HallowCharmItem.java
@@ -44,7 +44,7 @@ import java.util.Random;
 
 public class HallowCharmItem extends Item implements ITrinket {
 	
-	private static final Quaternion ROTATION_CONSTANT = Vector3f.POSITIVE_Z.getDegreesQuaternion(-180);
+	private static final Quaternion ROTATION_CONSTANT = new Quaternion(Vector3f.POSITIVE_Z, -180f, true);
 	
 	public HallowCharmItem(Settings settings) {
 		super(settings);

--- a/src/main/java/com/fabriccommunity/thehallow/item/SkirtCostumeItem.java
+++ b/src/main/java/com/fabriccommunity/thehallow/item/SkirtCostumeItem.java
@@ -28,7 +28,7 @@ import dev.emi.trinkets.api.Slots;
 
 public class SkirtCostumeItem extends Item implements ITrinket {
 	
-	private static final Quaternion ROTATION_CONSTANT = Vector3f.POSITIVE_Z.getDegreesQuaternion(-45f);
+	private static final Quaternion ROTATION_CONSTANT = new Quaternion(Vector3f.POSITIVE_Z, -45f, true);
 	
 	public SkirtCostumeItem(Settings settings) {
 		super(settings);


### PR DESCRIPTION
Whoops. Apparently Vector3f.getDegreesQuaternion is client-only and I didn't realize it. Thankfully this only affected two places, as every other use of it was in client code anyway. Dedicated server should launch now, and from a cursory check nothing seems to crash.